### PR TITLE
chore(workflow): update workflows to use AWS ECR and prevent triggers…

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: "Flag to install Docker Compose"
     required: false
     default: "true"
-    
+
 outputs: {}
 runs:
   using: "composite"

--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -1,24 +1,25 @@
 name: "Setup Docker Environment"
-description: "Reusable steps for setting up QEMU, Docker Buildx, DockerHub login, Supersetbot, and optionally Docker Compose"
+description: "Reusable steps for setting up QEMU, Docker Buildx, AWS ECR login, Supersetbot, and optionally Docker Compose"
 inputs:
   build:
     description: "Used for building?"
     required: false
     default: "false"
-  dockerhub-user:
-    description: "DockerHub username"
+  aws-access-key-id:
+    description: "AWS Access Key ID"
     required: false
-  dockerhub-token:
-    description: "DockerHub token"
+  aws-secret-access-key:
+    description: "AWS Secret Access Key"
     required: false
+  aws-region:
+    description: "AWS Region"
+    required: false
+    default: "us-west-2"
   install-docker-compose:
     description: "Flag to install Docker Compose"
     required: false
     default: "true"
-  login-to-dockerhub:
-    description: "Whether you want to log into dockerhub"
-    required: false
-    default: "true"
+    
 outputs: {}
 runs:
   using: "composite"
@@ -32,13 +33,16 @@ runs:
       if: ${{ inputs.build == 'true' }}
       uses: docker/setup-buildx-action@v3
 
-    - name: Try to login to DockerHub
-      if: ${{ inputs.login-to-dockerhub == 'true' }}
-      continue-on-error: true
-      uses: docker/login-action@v3
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        username: ${{ inputs.dockerhub-user }}
-        password: ${{ inputs.dockerhub-token }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Install Docker Compose
       if: ${{ inputs.install-docker-compose == 'true' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,9 @@
 name: Build & publish docker images
 
 on:
-  push:
-    branches:
-      - "master"
-      - "[0-9].[0-9]*"
   pull_request:
     branches:
-      - "master"
+      - "main"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/ephemeral-env.yml
+++ b/.github/workflows/ephemeral-env.yml
@@ -3,17 +3,9 @@ name: Ephemeral env workflow
 # Example manual trigger:  gh workflow run ephemeral-env.yml --ref fix_ephemerals  --field comment_body="/testenv up" --field issue_number=666
 
 on:
-  issue_comment:
-    types: [created]
-  workflow_dispatch:
-    inputs:
-      comment_body:
-        description: 'Comment body to simulate /testenv command'
-        required: true
-        default: '/testenv up'
-      issue_number:
-        description: 'Issue or PR number'
-        required: true
+  pull_request:
+    branches:
+      - "main"
 
 jobs:
   ephemeral-env-comment:

--- a/.github/workflows/latest-release-tag.yml
+++ b/.github/workflows/latest-release-tag.yml
@@ -1,7 +1,8 @@
 name: Tags
 on:
-  release:
-    types: [published] # This makes it run only when a new released is published
+  pull_request:
+    branches:
+      - "main"
 
 jobs:
   latest-release:

--- a/.github/workflows/release-docker-publish.yml
+++ b/.github/workflows/release-docker-publish.yml
@@ -1,0 +1,93 @@
+# .github/workflows/release-docker-publish.yml
+
+name: "Release Docker Publish"
+
+on:
+  release:
+    types: [published, edited]
+    # This event fires when you click "Publish release" in GitHub UI.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  release-docker:
+    # Only run if the release is targeting the master branch
+    if: ${{ github.event.release.target_commitish == 'master' }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: "Checkout Repository at Release Commit"
+        uses: actions/checkout@v4
+        with:
+          # Do not persist credentials to avoid modifying the repo
+          persist-credentials: false
+
+      - name: "Extract Version from Tag"
+        id: get_version
+        shell: bash
+        run: |
+          # GITHUB_REF might look like: refs/tags/v1.2.3
+          # Remove the "refs/tags/" prefix to get something like "v1.2.3"
+          VERSION="${GITHUB_REF#refs/tags/}"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: "Setup Docker Environment"
+        uses: ./.github/actions/setup-docker
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          build: "true"
+        # This custom action is expected to configure Docker & log into AWS ECR.
+        # Ensure no references to Docker Hub if you only use ECR.
+
+      - name: "Setup supersetbot"
+        uses: ./.github/actions/setup-supersetbot/
+        # Assuming this custom action is needed for your environment
+
+      - name: "Build & Push Docker Image (version + latest)"
+        shell: bash
+        env:
+          # Pass the version extracted from the tag
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Multi-architecture example. Adjust if you only need amd64.
+          PLATFORM_ARG="--platform linux/arm64 --platform linux/amd64"
+
+          # In a release workflow, we typically push.
+          PUSH_OR_LOAD="--push"
+
+          # Construct two tags:
+          # 1) Versioned tag, e.g. :GHA-v1.2.3
+          IMAGE_TAG_VERSION="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/superset:GHA-${VERSION}"
+
+          # 2) 'latest' tag
+          IMAGE_TAG_LATEST="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/superset:latest"
+
+          supersetbot docker \
+            $PUSH_OR_LOAD \
+            --preset "dev" \
+            --context "$EVENT" \
+            --context-ref "$RELEASE" $FORCE_LATEST \
+            --extra-flags "--build-arg INCLUDE_CHROMIUM=false --tag $IMAGE_TAG_VERSION --tag $IMAGE_TAG_LATEST" \
+            $PLATFORM_ARG
+
+          # If you use multiple presets or a different preset than "dev," adjust accordingly.
+
+      - name: "Pull & Verify Image (versioned)"
+        run: |
+          IMAGE_TAG="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/superset:GHA-${{ steps.get_version.outputs.VERSION }}"
+          docker pull "$IMAGE_TAG"
+
+      - name: "Print Docker Stats (versioned)"
+        run: |
+          IMAGE_TAG="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/superset:GHA-${{ steps.get_version.outputs.VERSION }}"
+          echo "Git SHA: ${{ github.sha }}"
+          echo "Image: $IMAGE_TAG"
+          docker images "$IMAGE_TAG"
+          docker history "$IMAGE_TAG"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,8 +1,9 @@
 name: Publish a Release
 
 on:
-  release:
-    types: [published, edited]
+  pull_request:
+    branches:
+      - "main"
 
   # Can be triggered manually
   workflow_dispatch:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR updates the GitHub Actions workflows to use AWS ECR instead of Docker Hub for Docker image storage. Additionally, it modifies the workflows to prevent triggers on the `master` branch or during releases.

A new workflow, `release-docker-publish.yml`, has been added. This workflow is triggered on release events and is responsible for:
- Checking out the repository at the release commit.
- Extracting the version from the tag.
- Setting up the Docker environment and logging into AWS ECR.
- Building and pushing Docker images with versioned and latest tags.
- Pulling and verifying the versioned Docker image.
- Printing Docker image statistics.

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Verify that the workflows no longer trigger on the `master` branch or during releases.
2. Ensure that Docker images are correctly built and pushed to AWS ECR.
3. Confirm that the workflows function as expected in other branches.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API